### PR TITLE
Add  basic plotting functions

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -22,6 +22,9 @@ jobs:
               uses: actions/setup-python@v5
               with:
                 python-version: ${{ matrix.python-version }}
+            
+            - name: Setup headless display
+              uses: pyvista/setup-headless-display-action@v3
 
             - name: Set up Poetry
               uses: abatilo/actions-poetry@v3

--- a/gdtchron/__init__.py
+++ b/gdtchron/__init__.py
@@ -7,6 +7,6 @@ Modules:
     visualization: Tools for visualizing VTK files and model thermochronometric ages.
 """
 
-from gdtchron.visualization import plot_vtk_2d
+from gdtchron.visualization import add_comp_field, plot_vtk_2d
 
-__all__ = ["plot_vtk_2d"]
+__all__ = ["plot_vtk_2d","add_comp_field"]

--- a/gdtchron/__init__.py
+++ b/gdtchron/__init__.py
@@ -9,4 +9,4 @@ Modules:
 
 from gdtchron.visualization import add_comp_field, plot_vtk_2d
 
-__all__ = ["plot_vtk_2d","add_comp_field"]
+__all__ = ["plot_vtk_2d", "add_comp_field"]

--- a/gdtchron/__init__.py
+++ b/gdtchron/__init__.py
@@ -1,1 +1,12 @@
-"""Placeholder docstring."""
+"""GDTchron.
+
+GDTchron is a Python package for using the outputs of geodynamic models to predict
+thermochronometric ages.
+
+Modules:
+    visualization: Tools for visualizing VTK files and model thermochronometric ages.
+"""
+
+from gdtchron.visualization import plot_vtk_2d
+
+__all__ = ["plot_vtk_2d"]

--- a/gdtchron/visualization.py
+++ b/gdtchron/visualization.py
@@ -1,0 +1,99 @@
+"""Module for visualizing VTK files and thermochronometric results."""
+import matplotlib.pyplot as plt
+import numpy as np
+import pyvista as pv
+
+ZOOM_FACTOR = 1.875
+
+
+def plot_vtk_2d(mesh,field,bounds=None,ax=None,colorbar=False,**kwargs):
+    """Plot 2D mesh using Pyvista on a Matplotlib axes.
+
+    Parameters
+    ----------
+    mesh : Pyvista mesh object
+        A pyvista mesh object that contains geometrical representations
+        of surface or volume data. The mesh may also have attributes,
+        such as data values assigned to points, cells, or fields assigning
+        various information to the mesh.
+    field : str
+        The name of the field contained within the Pyvista mesh object
+        to plot. 
+    bounds : list of floats or integers
+        A list of four values that define the bounds by which to clip the 
+        plot. Successively, the list of values define the minimum x,
+        maximum x, minimum y, and maximum y bounds. (default: None).
+    ax : Matplotlib axes object 
+        Matplotlib axis on which to plot the mesh (default: None).
+    colorbar : bool
+        Boolean (True or False) for whether to include colorbar (default: False).
+    **kwargs : dict
+        Additional keyword arguments to pass to the Pyvista plotter.
+    
+    Returns
+    -------
+    ax : Matplotlib axes object
+        Modified matplotlib axes object with the plotted mesh
+
+    """
+    if bounds is not None:
+        # Add placeholder Z values to bounds
+        bounds_3d = bounds + [0,0]
+        # Clip mesh by bounds
+        mesh = mesh.clip_box(bounds=bounds_3d,invert=False)
+    
+    # Set up Pyvista plotter offscreen
+    pv.set_plot_theme("document")
+    plotter = pv.Plotter(off_screen=True)
+    
+    # Add mesh to plotter
+    plotter.add_mesh(mesh,scalars=field,**kwargs)
+    
+    # Set plotter to XY view
+    plotter.view_xy()
+    
+    # Remove default colorbar if not enabled
+    if not colorbar:
+        plotter.remove_scalar_bar()
+
+    # Calculate Camera Position from Bounds
+    bounds_array = np.array(bounds)
+    xmag = float(abs(bounds_array[1] - bounds_array[0]))
+    ymag = float(abs(bounds_array[3] - bounds_array[2]))
+    aspect_ratio = ymag/xmag
+    
+    # Set a standard plotter window size
+    plotter.window_size = (1024,int(1024*aspect_ratio))
+    
+    # Define the X/Y midpoints, and zoom level. The ideal zoom factor of 1.875 
+    # was determined by trial and error
+    xmid = xmag / 2 + bounds_array[0]
+    ymid = ymag / 2 + bounds_array[2]
+    zoom = xmag * aspect_ratio * ZOOM_FACTOR
+    
+    # Set camera settings for plotter window
+    position = (xmid,ymid,zoom)
+    focal_point = (xmid,ymid,0)
+    viewup = (0,1,0)
+    
+    # Package camera settings as a list
+    camera = [position,focal_point,viewup]
+    
+    # Assign the camera to the settings
+    plotter.camera_position = camera
+    
+    # Create image
+    img = plotter.screenshot(transparent_background=True)
+    
+    # Get current axes if none defined
+    if ax is None:
+        ax = plt.gca()
+    
+    # Plot using imshow
+    ax.imshow(img,aspect='equal',extent=bounds)
+    
+    # Clear plot from memory
+    plotter.clear()
+    pv.close_all()
+    
+    return(ax)

--- a/gdtchron/visualization.py
+++ b/gdtchron/visualization.py
@@ -6,7 +6,7 @@ import pyvista as pv
 ZOOM_FACTOR = 1.875
 
 
-def plot_vtk_2d(mesh,field,bounds=None,ax=None,colorbar=False,**kwargs):
+def plot_vtk_2d(mesh, field, bounds=None, ax=None, colorbar=False, **kwargs):
     """Plot 2D mesh using Pyvista on a Matplotlib axes.
 
     Parameters
@@ -38,16 +38,16 @@ def plot_vtk_2d(mesh,field,bounds=None,ax=None,colorbar=False,**kwargs):
     """
     if bounds is not None:
         # Add placeholder Z values to bounds
-        bounds_3d = bounds + [0,0]
+        bounds_3d = bounds + [0, 0]
         # Clip mesh by bounds
-        mesh = mesh.clip_box(bounds=bounds_3d,invert=False)
+        mesh = mesh.clip_box(bounds=bounds_3d, invert=False)
     
     # Set up Pyvista plotter offscreen
     pv.set_plot_theme("document")
     plotter = pv.Plotter(off_screen=True)
     
     # Add mesh to plotter
-    plotter.add_mesh(mesh,scalars=field,**kwargs)
+    plotter.add_mesh(mesh, scalars=field, **kwargs)
     
     # Set plotter to XY view
     plotter.view_xy()
@@ -60,10 +60,10 @@ def plot_vtk_2d(mesh,field,bounds=None,ax=None,colorbar=False,**kwargs):
     bounds_array = np.array(bounds)
     xmag = float(abs(bounds_array[1] - bounds_array[0]))
     ymag = float(abs(bounds_array[3] - bounds_array[2]))
-    aspect_ratio = ymag/xmag
+    aspect_ratio = ymag / xmag
     
     # Set a standard plotter window size
-    plotter.window_size = (1024,int(1024*aspect_ratio))
+    plotter.window_size = (1024, int(1024 * aspect_ratio))
     
     # Define the X/Y midpoints, and zoom level. The ideal zoom factor of 1.875 
     # was determined by trial and error
@@ -72,12 +72,12 @@ def plot_vtk_2d(mesh,field,bounds=None,ax=None,colorbar=False,**kwargs):
     zoom = xmag * aspect_ratio * ZOOM_FACTOR
     
     # Set camera settings for plotter window
-    position = (xmid,ymid,zoom)
-    focal_point = (xmid,ymid,0)
-    viewup = (0,1,0)
+    position = (xmid, ymid, zoom)
+    focal_point = (xmid, ymid, 0)
+    viewup = (0, 1, 0)
     
     # Package camera settings as a list
-    camera = [position,focal_point,viewup]
+    camera = [position, focal_point, viewup]
     
     # Assign the camera to the settings
     plotter.camera_position = camera
@@ -90,15 +90,16 @@ def plot_vtk_2d(mesh,field,bounds=None,ax=None,colorbar=False,**kwargs):
         ax = plt.gca()
     
     # Plot using imshow
-    ax.imshow(img,aspect='equal',extent=bounds)
+    ax.imshow(img, aspect='equal', extent=bounds)
     
     # Clear plot from memory
     plotter.clear()
     pv.close_all()
     
-    return(ax)
+    return (ax)
 
-def add_comp_field(mesh,fields=None):
+
+def add_comp_field(mesh, fields=None):
     """Assign compositional field as a single scalar from multiple scalars.
     
     Compositional fields in VTK files are often defined using multiple scalars, where
@@ -136,7 +137,7 @@ def add_comp_field(mesh,fields=None):
     """
     # Assign defaults if not specified
     if fields is None:
-        fields = ['crust_upper','crust_lower','mantle_lithosphere']
+        fields = ['crust_upper', 'crust_lower', 'mantle_lithosphere']
     
     # Convert single str to list
     if isinstance(fields, str):
@@ -149,8 +150,8 @@ def add_comp_field(mesh,fields=None):
     # value is greater than 0.5
     for x in range(len(fields)):
         array = mesh.point_data[fields[x]]
-        output = np.where(array>0.5,x+1,output)
+        output = np.where(array > 0.5, x + 1, output)
     
     # Assign field to the data point in the mesh
     mesh.point_data['comp_field'] = output
-    return(mesh)
+    return (mesh)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,16 +26,17 @@ ruff = "^0.11"
 
 [tool.ruff]
 lint.select = [
-  "E", "F", "B", "I", "D", "N", "UP", "C4", "SIM", "T20"
+  "E", "F", "B", "I", "D", "D417", "N", "UP", "C4", "SIM", "T20"
 ]
 preview=true
 
 lint.ignore = [
-  "D100",  # Ignore missing docstring in public module
-  "D107",  # Ignore missing docstring in __init__
   "D203",  # Ignore incorrect blank line before class
   "D213",  # Ignore multi line summary second line
 ]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ ruff = "^0.11"
 lint.select = [
   "E", "F", "B", "I", "D", "N", "UP", "C4", "SIM", "T20"
 ]
+preview=true
 
 lint.ignore = [
   "D100",  # Ignore missing docstring in public module

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,4 +1,0 @@
-"""Placeholder test file."""
-def test_placeholder():
-    """Placeholder docstring."""
-    assert True

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -3,14 +3,17 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pyvista as pv
 
-from gdtchron import plot_vtk_2d
+from gdtchron import add_comp_field, plot_vtk_2d
 
-# Create very small mesh of 9 cells with 16 points and assign each a value
+# Create very small mesh with 16 points and assign each a value
 mesh = pv.ImageData(dimensions=(4, 4, 1)).cast_to_unstructured_grid()
-mesh['sample_field'] = np.arange(9)
+mesh['sample_field'] = np.arange(16)
 
 def test_plot_vtk_2d():
     """Test plot_vtk_2d function."""
+    # Test that sample_field in the mesh
+    assert 'sample_field' in mesh.point_data
+
     # Create Matplotlib figure/axes
     fig,ax = plt.subplots(1)
 
@@ -30,3 +33,43 @@ def test_plot_vtk_2d():
 
     # Test that the axes y limits are correct
     assert ax.get_ylim() == (0,2)
+
+def test_add_comp_field():
+    """Test add_comp_field function."""
+    # Test basic functionality using sample field
+    mesh_comp_field = add_comp_field(mesh,'sample_field')
+
+    # Ensure comp_field is created
+    assert 'comp_field' in mesh_comp_field.point_data
+
+    # Both sample_field and null should be present
+    assert 1 in mesh_comp_field['comp_field']
+    assert 0 in mesh_comp_field['comp_field']
+
+    # Test functionality with default fields
+
+    # Create random arrays between 0 and 1 for each field
+    rng = np.random.default_rng(seed=15)
+    mesh['crust_upper'] = rng.random(16)
+    mesh['crust_lower'] = rng.random(16)
+    mesh['mantle_lithosphere'] = rng.random(16)
+    
+    # Ensure one point will be assigned null value
+    mesh['crust_upper'][-1] = 0
+    mesh['crust_lower'][-1] = 0
+    mesh['mantle_lithosphere'][-1] = 0
+
+    # Run function with defaults
+    mesh_comp_defaults = add_comp_field(mesh)
+
+    # Ensure comp_field is created
+    assert 'comp_field' in mesh_comp_defaults.point_data
+
+    # All field and null should be present
+    assert 3 in mesh_comp_defaults['comp_field']
+    assert 2 in mesh_comp_defaults['comp_field']
+    assert 1 in mesh_comp_defaults['comp_field']
+    assert 0 in mesh_comp_defaults['comp_field']
+
+
+

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,0 +1,32 @@
+"""Tests for visualization module."""
+import matplotlib.pyplot as plt
+import numpy as np
+import pyvista as pv
+
+from gdtchron import plot_vtk_2d
+
+# Create very small mesh of 9 cells with 16 points and assign each a value
+mesh = pv.ImageData(dimensions=(4, 4, 1)).cast_to_unstructured_grid()
+mesh['sample_field'] = np.arange(9)
+
+def test_plot_vtk_2d():
+    """Test plot_vtk_2d function."""
+    # Create Matplotlib figure/axes
+    fig,ax = plt.subplots(1)
+
+    # Attempt to plot the mesh on the axes, colored by the sample field and with
+    # bounds restricted to 0-2 on the x and y axes.
+    ax = plot_vtk_2d(mesh,'sample_field',bounds=[0,2,0,2],
+                                       ax=ax)
+
+    # Test that the figure contains 1 axes
+    assert len(fig.get_axes()) == 1
+    
+    # Test that the axes contains 1 image
+    assert len(ax.get_images()) == 1
+    
+    # Test that the axes x limits are correct
+    assert ax.get_xlim() == (0,2)
+
+    # Test that the axes y limits are correct
+    assert ax.get_ylim() == (0,2)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -9,17 +9,18 @@ from gdtchron import add_comp_field, plot_vtk_2d
 mesh = pv.ImageData(dimensions=(4, 4, 1)).cast_to_unstructured_grid()
 mesh['sample_field'] = np.arange(16)
 
+
 def test_plot_vtk_2d():
     """Test plot_vtk_2d function."""
     # Test that sample_field in the mesh
     assert 'sample_field' in mesh.point_data
 
     # Create Matplotlib figure/axes
-    fig,ax = plt.subplots(1)
+    fig, ax = plt.subplots(1)
 
     # Attempt to plot the mesh on the axes, colored by the sample field and with
     # bounds restricted to 0-2 on the x and y axes.
-    ax = plot_vtk_2d(mesh,'sample_field',bounds=[0,2,0,2],
+    ax = plot_vtk_2d(mesh, 'sample_field', bounds=[0, 2, 0, 2],
                                        ax=ax)
 
     # Test that the figure contains 1 axes
@@ -29,15 +30,16 @@ def test_plot_vtk_2d():
     assert len(ax.get_images()) == 1
     
     # Test that the axes x limits are correct
-    assert ax.get_xlim() == (0,2)
+    assert ax.get_xlim() == (0, 2)
 
     # Test that the axes y limits are correct
-    assert ax.get_ylim() == (0,2)
+    assert ax.get_ylim() == (0, 2)
+
 
 def test_add_comp_field():
     """Test add_comp_field function."""
     # Test basic functionality using sample field
-    mesh_comp_field = add_comp_field(mesh,'sample_field')
+    mesh_comp_field = add_comp_field(mesh, 'sample_field')
 
     # Ensure comp_field is created
     assert 'comp_field' in mesh_comp_field.point_data


### PR DESCRIPTION
This adds the basic 2d VTK plotter (using Pyvista) that was part of the old vtk_plot.py function list. Note that I pulled this from the version in GDMATE and it has some slight differences - mainly that it needs a Pyvista mesh as the input rather than the location of a VTK file, which I think makes it more versatile. It does mean that the usage will change in all the Jupyter Notebooks in the other repository when we start migrating those.

This is also an opportunity to decide on a style for things like docstrings and then use this function as a guide for future additions and for a possible style guide in the documentation. This is basically currently the style we used for GDMATE modified in response to style rules from Ruff.