### PR TITLE
Add setup files for Binder

### DIFF
--- a/.binder/apt.txt
+++ b/.binder/apt.txt
@@ -1,0 +1,4 @@
+# This file identifies apt packages needed for Binder to use Pyvista 
+# in headless mode.
+libgl1-mesa-glx
+xvfb

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,0 +1,11 @@
+name: gdtchron-binder
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  - jupyterlab
+  - opencv
+  - cmcrameri
+  - pip
+  - pip:
+      - ..

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ git clone https://github.com/dyvasey/gdtchron.git
 cd gdtchron
 pip install .
 ```
+
+## Running GDTchron with Binder
+Clicking the Binder badge at the top of this README will launch an interactive JupyterLab environment hosted by Binder with GDTchron installed. This is a good way to try out the functionality of GDTchron without needing to deal with a local Python installation. Note that the Binder environment does not have ASPECT installed.
+
 ## Running GDTchron with ASPECT via Docker
 Included in this repository is a Dockerfile allowing you to create an interactive JupyterLab environment that can run both ASPECT and GDTchron in Jupyter Notebooks.
 


### PR DESCRIPTION
This is a few configuration files so that clicking the Binder badge in the README will allow one to run GDTchron. It also includes a brief description for the README. Addresses #6 

To test Binder on this branch, click: https://mybinder.org/v2/gh/dyvasey/gdtchron/binder