### PR TITLE
Make defaults align between He and AFT forward models

### DIFF
--- a/gdtchron/he.py
+++ b/gdtchron/he.py
@@ -574,7 +574,7 @@ def profile_to_age(x, node_positions, radius, uth_molg, stop_distances):
 
 
 def forward_model_he(temps, tsteps, system, u, th, radius, nodes=513,
-                     initial_x=None, return_all=True):
+                     initial_x=None, return_all=False):
     """Forward model a (U-Th)/He age for a particular time-temperature path.
     
     Uses finite difference method for diffusion within a sphere as described 
@@ -599,7 +599,7 @@ def forward_model_he(temps, tsteps, system, u, th, radius, nodes=513,
     radius : float
         Radius of the grain (micrometers)
     nodes : float, optional
-        Number of nodes to model within the crystal. The default is 513.
+        Number of nodes to model within the crystal. (default: 513)
     initial_x : NumPy array of floats or None, optional
         Array containing the initial values for x (mol * micrometers / g). If 
         all values in the array are np.nan or initial_x is set to None, this 
@@ -608,7 +608,7 @@ def forward_model_he(temps, tsteps, system, u, th, radius, nodes=513,
     return_all : bool
         Boolean indicating whether to return additional values calculated by
         the functions as a part of the forward model. If False, only the 
-        corrected age is returned.
+        corrected age is returned. (default: False)
 
     Returns
     -------
@@ -628,7 +628,7 @@ def forward_model_he(temps, tsteps, system, u, th, radius, nodes=513,
         Radial profile of He, normalized so that the position with the highest
         concentration has a value of 1.
         Returned if return_all is True.
-    x : NumPy array of floats
+    x : NumPy array of floats (optional)
         Matrix x solved for using Equation 21 Ketcham (2005). 
         Equivalent to the concentration times the node position.
         Returned if return_all is True.

--- a/notebooks/tchron_demo.ipynb
+++ b/notebooks/tchron_demo.ipynb
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -99,12 +99,12 @@
    "source": [
     "# Calculate AHe and ZHe ages\n",
     "results_ahe = he.forward_model_he(temps=temps, tsteps=time, system='AHe', u=100, th=100,\n",
-    "                                  radius=50)\n",
+    "                                  radius=50, return_all=True)\n",
     "\n",
     "print('AHe Age: ', round(results_ahe[0], 2), ' Ma')\n",
     "\n",
     "results_zhe = he.forward_model_he(temps=temps, tsteps=time, system='ZHe', u=100, th=100,\n",
-    "                                  radius=50)\n",
+    "                                  radius=50, return_all=True)\n",
     "\n",
     "print('ZHe Age: ', round(results_zhe[0], 2), ' Ma')\n"
    ]

--- a/tests/test_he.py
+++ b/tests/test_he.py
@@ -321,7 +321,8 @@ def test_forward_model_he():
                               system='AHe',
                               u=U,
                               th=TH,
-                              radius=RADIUS)
+                              radius=RADIUS,
+                              return_all=True)
 
     assert v_normalized[0] == pytest.approx(1)
     assert v_normalized[np.argmin(np.abs(node_positions - 80))] == \
@@ -349,7 +350,8 @@ def test_forward_model_he():
                               system='AHe',
                               u=U,
                               th=TH,
-                              radius=RADIUS)
+                              radius=RADIUS,
+                              return_all=True)
 
     assert v_normalized[0] == pytest.approx(1)
     assert v_normalized[np.argmin(np.abs(node_positions - 28))] == \
@@ -381,7 +383,8 @@ def test_forward_model_he():
                               system='AHe',
                               u=U,
                               th=TH,
-                              radius=RADIUS)
+                              radius=RADIUS,
+                              return_all=True)
 
     assert v_normalized[0] == pytest.approx(1)
     assert v_normalized[np.argmin(np.abs(node_positions - 20))] == \


### PR DESCRIPTION
This PR addresses #22 by updating the (U-Th) / He forward model to return only the corrected age by default. I also made some minor changes to the function's docstring and updated the forward model tests to account for the new default.

(I think it'll be easier for my workflow to make this PR separately from my work on `_parallel_vtk.py`.)