### PR TITLE
Parallel vtk final

### DIFF
--- a/gdtchron/__init__.py
+++ b/gdtchron/__init__.py
@@ -1,6 +1,9 @@
 """GDTchron - Geodynamic Thermochronology"""  # noqa: D400
 
 from gdtchron import aft, he
+from gdtchron._parallel_vtk import run_tt_paths, run_vtk
 from gdtchron._visualization import add_comp_field, plot_vtk_2d
 
-__all__ = ["plot_vtk_2d", "add_comp_field", "aft", "he"]
+__all__ = ["plot_vtk_2d", "add_comp_field", 
+           "aft", "he",
+           "run_tt_paths", "run_vtk"]

--- a/gdtchron/_parallel_vtk.py
+++ b/gdtchron/_parallel_vtk.py
@@ -1,8 +1,8 @@
-"""Module for running forward models across multiple T-t paths and VTK meshes.
+"""Module for running forward models across multiple t-T paths and VTK meshes.
 
 This module includes a function for running forward models across multiple
 user-provided t-T paths (run_tt_paths) and a function to run forward models
-across the T-t paths experienced by different particles across a series of
+across the t-T paths experienced by different particles across a series of
 VTK meshes (run_vtk)
 """
 
@@ -38,28 +38,28 @@ def run_particle_he(particle_id, inputs, calc_age, interpolate_vals,
         k : any
             Unused parameter (included here for symmetry with the inputs of
             run_particle_aft)
-        positions : pyvista.core.pyvista_ndarray.pyvista_ndarray
+        positions : PyVista array
             x, y, z coordinates of each particle in current mesh
-        tree : scipy.spatial._kdtree.KDTree or None
+        tree : SciPy KDTree or None
             K-d tree containing the positions of particles from the previous
             timestep. Unused (and typically set to None) if interpolate_vals
             is False.
-        ids : pyvista.core.pyvista_ndarray.pyvista_ndarray
+        ids : PyVista array
             IDs for all particles from the current timestep
-        old_ids : pyvista.core.pyvista_ndarray.pyvista_ndarray
+        old_ids : PyVista array
             IDs for all particles from the previous timestep
-        tree_ids : pyvista.core.pyvista_ndarray.pyvista_ndarray or None
+        tree_ids : PyVista array
             IDs for all particles with profiles from the previous timestep. Not
             used and typically set to None if interpolate_vals is True
-        mesh_temps : pyvista.core.pyvista_ndarray.pyvista_ndarray
-            Temperatures for all particles from the current timestep
-        old_temps : pyvista.core.pyvista_ndarray.pyvista_ndarray
-            Temperatures for all particles from the previous timestep
+        mesh_temps : PyVista array
+            Temperatures (K) for all particles from the current timestep
+        old_temps : PyVista array
+            Temperatures (K) for all particles from the previous timestep
         old_profiles : NumPy ndarray of NumPy arrays of floats
             Profiles of x values for all particles.
         time_interval : float
             Time elapsed between mesh files (Myr)
-        system : string
+        system : str
             Isotopic system to model. Valid options are 'AHe' (apatite He) or
             'ZHe' (zircon He)
         num_nodes : int
@@ -88,10 +88,11 @@ def run_particle_he(particle_id, inputs, calc_age, interpolate_vals,
     -------
     age : float
         Age of the particle. This equals np.nan if calc_age is False or there
-        is an issue obtaining the age of the particle
+        is an issue obtaining the age of the particle.
     x : NumPy array of floats
-        Matrix x solved for using Equation 21 in Ketcham (2005) (in that paper,
-        x is referred to as u).
+        Matrix x solved for using Equation 21 in Ketcham (2005). In that 
+        equation, x is referred to as u. We use x here to avoid confusing this 
+        variable for uranium (u).
         Equivalent to the He concentration (mol / g) times the node position
         (micrometers).
 
@@ -148,7 +149,7 @@ def run_particle_he(particle_id, inputs, calc_age, interpolate_vals,
             try:
                 profile = old_profiles[neighbor_id == old_ids]
             except Exception:
-                warnings.warn("Warning: likely multi-dimensional id", 
+                warnings.warn("Warning: 2+ particles likely have the same ID", 
                               stacklevel=2)
                 x = np.empty(num_nodes, dtype=dtype)
                 x.fill(dtype(np.inf))
@@ -170,7 +171,7 @@ def run_particle_he(particle_id, inputs, calc_age, interpolate_vals,
         age = np.nan
         return (age, profile[0])
         
-    # passing start and end temperatures to forward model
+    # Passing start and end temperatures to forward model
     particle_temps = np.array([particle_start_temp[0], particle_end_temp[0]])
     particle_tsteps = np.array([time_interval, 0])
 
@@ -206,28 +207,28 @@ def run_particle_ft(particle_id, inputs, calc_age, interpolate_vals):
     inputs : tuple
         k : int
             Index of the current timestep/mesh being processed.
-        positions : pyvista.core.pyvista_ndarray.pyvista_ndarray
+        positions : PyVista array
             x, y, z coordinates of each particle in current mesh
-        tree : scipy.spatial._kdtree.KDTree or None
+        tree : SciPy KDTree or None
             K-d tree containing the positions of particles from the previous
             timestep. Unused (and typically set to None) if interpolate_vals
             is False.
-        ids : pyvista.core.pyvista_ndarray.pyvista_ndarray
+        ids : PyVista array
             IDs for all particles from the current timestep
-        old_ids : pyvista.core.pyvista_ndarray.pyvista_ndarray
+        old_ids : PyVista array
             IDs for all particles from the previous timestep
-        tree_ids : pyvista.core.pyvista_ndarray.pyvista_ndarray or None
+        tree_ids : PyVista array
             IDs for all particles with profiles from the previous timestep. Not
             used (and typically set to False) if interpolate_vals is True.
-        mesh_temps : pyvista.core.pyvista_ndarray.pyvista_ndarray
-            Temperatures for all particles from the current timestep
-        old_temps : pyvista.core.pyvista_ndarray.pyvista_ndarray
-            Temperatures for all particles from the previous timestep
+        mesh_temps : PyVista array
+            Temperatures (K) for all particles from the current timestep
+        old_temps : PyVista array
+            Temperatures (K) for all particles from the previous timestep
         old_annealing_arrays : NumPy ndarray of NumPy arrays of floats
             r values for all particles from the previous timestep
         time_interval : float
             Time elapsed between mesh files (Myr)
-        system : string
+        system : str
             Isotopic system to model. Not used for FT system (but included as a
             parameter for symmetry with run_particle_he)
         r_length : int
@@ -235,7 +236,7 @@ def run_particle_ft(particle_id, inputs, calc_age, interpolate_vals):
         model_inputs : tuple       
             dpar : float
                 Etch figure length (micrometers).
-            annealing_model : string
+            annealing_model : str
                 Annealing model to use. Currently, the only acceptable value is
                 'Ketcham99', which corresponds to the fanning curvilinear model 
                 from Ketcham et al. (1999).
@@ -254,7 +255,7 @@ def run_particle_ft(particle_id, inputs, calc_age, interpolate_vals):
         Age of the particle. This equals np.nan if calc_age is False or there
         is an issue obtaining the age of the particle
     r : NumPy array of floats
-        Updated reduced lengths (unitless) for a hyppothetical grain located 
+        Updated reduced lengths (unitless) for a hypothetical grain located 
         within this particle.
 
     """
@@ -316,7 +317,7 @@ def run_particle_ft(particle_id, inputs, calc_age, interpolate_vals):
             try:
                 r_initial = old_annealing_arrays[neighbor_id == old_ids][0]
             except Exception:
-                warnings.warn("Warning: likely multi-dimensional id", 
+                warnings.warn("Warning: 2+ particles likely have the same ID", 
                               stacklevel=2)
                 x = np.empty(r_length, dtype=dtype)
                 x.fill(dtype(np.inf))
@@ -379,53 +380,54 @@ def run_vtk(files, system, time_interval,
     
     Parameters
     ----------
-    files : list of strings
-        List of paths to vtu files to run forward model on. Files are
+    files : list of str
+        List of paths to VTK files to run forward model on. Files are
         processed in the order they are given in the list.
-    system : string
-        Isotopic system to model. Current options are:
-            'AHe': Apatite (U-Th) / He
-            'ZHe': Zircon (U-Th) / He
-            'AFT': Apatite Fission Track
+    system : str
+        Isotopic system to model. Current options include 'AHe': Apatite 
+        (U-Th)/He, 'ZHe': Zircon (U-Th)/He, 'AFT': Apatite Fission Track
     time_interval : float
         Interval (Myrs) between times when each mesh was produced
     u : float, optional
-        U concentration (ppm). Default is 100 ppm. Only used if system is 'AHe'
-        or 'ZHe'.
+        U concentration (ppm) (default: 100). Only used if system is 'AHe' or 
+        'ZHe'.
     th : float, optional
-        Th concentration (ppm). Default is 100 ppm. Only used if system is 'AHe'
-        or 'ZHe'.
+        Th concentration (ppm) (default: 100). Only used if system is 'AHe' or 
+        'ZHe'.
     num_nodes : int 
         Number of nodes within the grain (for He) (default: 513). Unused for FT 
-        system
+        system.
     radius : float, optional
-        Radius of the grain (micrometers). Default is 50 micrometers. Only used 
+        Radius of the grain (micrometers) (default: 50). Only used 
         if system is 'AHe' or 'ZHe'.
     dpar : float, optional
-        Etch figure length (micrometers). Default is 1.75 micrometers. Only used
+        Etch figure length (micrometers) (default: 1.75). Only used
         if system is 'AFT'.
-    annealing_model : string, optional
+    annealing_model : str, optional
         Annealing model to use. Currently, the only acceptable value is
         'Ketcham99', which corresponds to the fanning curvilinear model from
-        Ketcham et al. (1999). Default is 'Ketcham99'. Only used if system is
+        Ketcham et al. (1999) (default: 'Ketcham99'). Only used if system is
         'AFT'.
-    file_prefix : string
+    file_prefix : str
         Prefix to give output files (default: 'meshes_tchron')
-    path : string
+    path : str
         Path to output directory (default: './')
-    temp_dir : string
-        Path to temporary output directory
+    temp_dir : str
+        Path to output directory used to temporarily dump data that does not 
+        fit in memory.
     batch_size : int or 'auto', optional
-        Number of batches to be dispatched to each worker at a time during 
+        Number of jobs to be dispatched to each worker at a time during 
         parallel computation (default: 100). If set to 'auto', this value is
         dynamically adjusted during computations to try to optimize efficiency.
+        However, on most test systems, better efficiency is gained by manually 
+        setting batch size to 100 or 1000 than using 'auto'.
     processes : int or None, optional
         Maximum number of processes that can run concurrently. If None, this
         parameter is internally set to two less than the number of CPUs on the
         user's system (default: None).
     interpolate_vals : bool
         Boolean indicating whether to interpolate particle data from nearest 
-        neighbor if the particle itself lacks He data. If False and the
+        neighbor if the particle itself lacks He or FT data. If False and the
         particle is missing data, an age of np.nan is returned for that 
         particle. (default: True)
     all_timesteps : bool
@@ -437,10 +439,6 @@ def run_vtk(files, system, time_interval,
         this function skips timesteps that already have data for this system
         and uses that data and uses for calculations in subsequent meshes. 
         (default: False)
-
-    Returns
-    -------
-    This function does not return any values.
 
     """
     dtype = np.float32
@@ -458,7 +456,7 @@ def run_vtk(files, system, time_interval,
     # Setting up directory for temporary memory dumps
     temp_dir = os.path.expanduser(temp_dir)
     
-    with suppress(Exception):
+    with suppress(FileNotFoundError):
         shutil.rmtree(temp_dir)
     
     os.makedirs(temp_dir)
@@ -471,7 +469,7 @@ def run_vtk(files, system, time_interval,
     cache_path = os.path.join(output_dir, 'cache_internal_vals.npy')
     
     # internal_len represents the length of the "internal values" array
-    # for the inputted annealing system. For the (U-Th)/He system, this
+    # for the input annealing system. For the (U-Th)/He system, this
     # array is a profile of x values (He concentration times node position)
     # across all nodes in a grain. For the AFT system, this array contains mean 
     # reduced lengths of fission tracks formed at each timestep.
@@ -504,7 +502,7 @@ def run_vtk(files, system, time_interval,
                 if overwrite or system not in original_mesh.point_data:
                     mesh = original_mesh
                 else:       
-                    # If this mesh exists and has data for the inputted
+                    # If this mesh exists and has data for the input
                     # thermochronologic system, we now need to see if this is
                     # the last mesh with data
                     next_filename = file_prefix + '_' + \
@@ -579,7 +577,7 @@ def run_vtk(files, system, time_interval,
 
                     # Note: At k=0, all particles have internal_vals but
                     #       they're all set to NaN, so what we used above
-                    #       doesn't and work and we need a special case
+                    #       doesn't work for k=1 and we need a special case
                     if k == 1:
                         tree_ids = old_ids
                         other_positions = old_positions
@@ -610,7 +608,8 @@ def run_vtk(files, system, time_interval,
                 output = parallel(
                     delayed(particle_fn[system])
                     (particle, inputs, calc_age, interpolate_vals)
-                    for particle in tqdm(ids, position=0, desc=prog_bar_txt)
+                    for particle in tqdm(ids, position=0, 
+                                         desc=prog_bar_txt, leave=False)
                     )
                 
                 ages, new_internal_vals = zip(*output)
@@ -626,7 +625,7 @@ def run_vtk(files, system, time_interval,
                 mesh.save(outfile_path)
                 
                 # Purge the temp folder
-                with suppress(Exception):
+                with suppress(FileNotFoundError):
                     shutil.rmtree(temp_dir)
                 os.makedirs(temp_dir)
     
@@ -656,32 +655,32 @@ def run_tt_paths(temp_paths, tsteps, system,
         Each pair of adjacent times composes a timestep. The time at a given
         index i corresponds to the temperatures at index i of each of the NumPy
         arrays in temp_paths.
-    system : string
-        Isotopic system to model. Current options are:
-            'AHe': Apatite (U-Th) / He
-            'ZHe': Zircon (U-Th) / He
-            'AFT': Apatite Fission Track
+    system : str
+        Isotopic system to model. Current options include 'AHe': Apatite 
+        (U-Th)/He, 'ZHe': Zircon (U-Th)/He, 'AFT': Apatite Fission Track
     u : float, optional
-        U concentration (ppm). Default is 100 ppm. Only used if system is 'AHe'
+        U concentration (ppm) (default: 100). Only used if system is 'AHe'
         or 'ZHe'.
     th : float, optional
-        Th concentration (ppm). Default is 100 ppm. Only used if system is 'AHe'
+        Th concentration (ppm) (default: 100). Only used if system is 'AHe'
         or 'ZHe'.
     radius : float, optional
-        Radius of the grain (micrometers). Default is 50 micrometers. Only used 
+        Radius of the grain (micrometers) (default: 50). Only used 
         if system is 'AHe' or 'ZHe'.
     dpar : float, optional
-        Etch figure length (micrometers). Default is 1.75 micrometers. Only used
+        Etch figure length (micrometers) (default: 1.75). Only used
         if system is 'AFT'.
-    annealing_model : string, optional
+    annealing_model : str, optional
         Annealing model to use. Currently, the only acceptable value is
         'Ketcham99', which corresponds to the fanning curvilinear model from
-        Ketcham et al. (1999). Default is 'Ketcham99'. Only used if system is
+        Ketcham et al. (1999) (default: 'Ketcham99'). Only used if system is
         'AFT'.
     batch_size : int or 'auto', optional
-        Number of batches to be dispatched to each worker at a time during 
+        Number of jobs to be dispatched to each worker at a time during 
         parallel computation (default: 100). If set to 'auto', this value is
         dynamically adjusted during computations to try to optimize efficiency.
+        However, on most test systems, better efficiency is gained by manually 
+        setting batch size to 100 or 1000 than using 'auto'.
     processes : int or None, optional
         Maximum number of processes that can run concurrently. If None, this
         parameter is internally set to two less than the number of CPUs on the
@@ -694,7 +693,7 @@ def run_tt_paths(temp_paths, tsteps, system,
     -------
     ages : list of floats
         Thermochronometric ages for the given isotopic system for grains that 
-        experienced each of the provided time series. All (U-Th) / He ages 
+        experienced each of the provided time series. All (U-Th)/He ages 
         returned are corrected ages. 
     
     """

--- a/gdtchron/_parallel_vtk.py
+++ b/gdtchron/_parallel_vtk.py
@@ -1,0 +1,727 @@
+"""Module for running forward models across multiple T-t paths and VTK meshes.
+
+This module includes a function for running forward models across multiple
+user-provided t-T paths (run_tt_paths) and a function to run forward models
+across the T-t paths experienced by different particles across a series of
+VTK meshes (run_vtk)
+"""
+
+import gc
+import os
+import shutil
+import warnings
+from contextlib import suppress
+
+import numpy as np
+import pyvista as pv
+from joblib import Parallel, delayed
+from scipy.spatial import KDTree
+from tqdm import tqdm
+
+from gdtchron import aft, he
+
+
+def run_particle_he(particle_id, inputs, calc_age, interpolate_vals,
+                        dtype=np.float32):  
+    """Calculate profile of x values for a particular ASPECT particle.
+
+    Function to calculate the profile of x values (He concentrations times
+    node positions) across all nodes within a hypothetical grain found in 
+    a given particle. This function's primary purpose is to be run in
+    parallel by run_vtk.
+
+    Parameters
+    ----------
+    particle_id : int
+        ID corresponding to the particle to get the He profile of
+    inputs : tuple
+        k : any
+            Unused parameter (included here for symmetry with the inputs of
+            run_particle_aft)
+        positions : pyvista.core.pyvista_ndarray.pyvista_ndarray
+            x, y, z coordinates of each particle in current mesh
+        tree : scipy.spatial._kdtree.KDTree or None
+            K-d tree containing the positions of particles from the previous
+            timestep. Unused (and typically set to None) if interpolate_vals
+            is False.
+        ids : pyvista.core.pyvista_ndarray.pyvista_ndarray
+            IDs for all particles from the current timestep
+        old_ids : pyvista.core.pyvista_ndarray.pyvista_ndarray
+            IDs for all particles from the previous timestep
+        tree_ids : pyvista.core.pyvista_ndarray.pyvista_ndarray or None
+            IDs for all particles with profiles from the previous timestep. Not
+            used and typically set to None if interpolate_vals is True
+        mesh_temps : pyvista.core.pyvista_ndarray.pyvista_ndarray
+            Temperatures for all particles from the current timestep
+        old_temps : pyvista.core.pyvista_ndarray.pyvista_ndarray
+            Temperatures for all particles from the previous timestep
+        old_profiles : NumPy ndarray of NumPy arrays of floats
+            Profiles of x values for all particles.
+        time_interval : float
+            Time elapsed between mesh files (Myr)
+        system : string
+            Isotopic system to model. Valid options are 'AHe' (apatite He) or
+            'ZHe' (zircon He)
+        num_nodes : int
+            Number of nodes to use within each profile
+        model_inputs : tuple
+            u : float
+                U concentration (ppm). 
+            th : float
+                Th concentration (ppm).
+            radius : float
+                Radius of the grain (micrometers).
+    calc_age : bool
+        Boolean indicating whether to calculate age of particle. If False,
+        age is returned as np.nan. Note that setting this to False will not
+        substantially improve the speed of calculations for this function.
+    interpolate_vals : bool
+        Boolean indicating whether to interpolate He data from nearest neighbor
+        of the particle if the particle itself lacks He data. If False and the
+        particle is missing He data, an age of np.nan and a profile filled with 
+        np.inf are returned.
+    dtype : type
+        Type of numbers used for calculations (default: np.float32). 32-bit 
+        floats are preferred to save memory.
+
+    Returns
+    -------
+    age : float
+        Age of the particle. This equals np.nan if calc_age is False or there
+        is an issue obtaining the age of the particle
+    x : NumPy array of floats
+        Matrix x solved for using Equation 21 in Ketcham (2005) (in that paper,
+        x is referred to as u).
+        Equivalent to the He concentration (mol / g) times the node position
+        (micrometers).
+
+    """
+    # Unpack inputs
+    (k, positions, tree, ids, old_ids, tree_ids, mesh_temps, old_temps, 
+     old_profiles, time_interval, system, num_nodes, (u, th, radius)) = inputs
+    
+    # Get old profile and temperature for current particle if present
+    profile = old_profiles[particle_id == old_ids]
+    particle_start_temp = old_temps[particle_id == old_ids]
+
+    # Create variable to track if missing old data for particle
+    missing = False
+     
+    # If array is empty, assign np.nan
+    # If the initial array is filled with np.inf (i.e, we have a bugged
+    # particle), then return (NaN, initial array)
+    # Otherwise, assign new value from old profile
+    if profile.size == 0:
+        profile = np.empty(num_nodes, dtype=dtype)
+        profile.fill(np.nan)
+        missing = True
+    elif profile[0][0] == dtype(np.inf):
+        age = np.nan
+        return (age, profile[0])
+    
+    # Get particle temperature
+    particle_end_temp = mesh_temps[ids == particle_id]
+       
+    # If particle not found, don't attempt to calculate profile or age
+    if particle_end_temp.size == 0:            
+        x = np.empty(num_nodes, dtype=dtype)
+        x.fill(dtype(np.inf))
+        age = np.nan
+        return (age, x)
+    
+    if missing:
+        
+        # Use previous He from nearest neighbor in previous timestep if needed
+        if interpolate_vals:
+        
+            # Get particle position
+            particle_position = positions[ids == particle_id]
+            
+            # Find closest particle
+            distance, index = tree.query(particle_position)
+            
+            # Get id of closest particle
+            neighbor_id = tree_ids[index]
+
+            # Get profile of closest particle
+            # Note: Sometimes particles can get bugged and have duplicate ids
+            try:
+                profile = old_profiles[neighbor_id == old_ids]
+            except Exception:
+                warnings.warn("Warning: likely multi-dimensional id", 
+                              stacklevel=2)
+                x = np.empty(num_nodes, dtype=dtype)
+                x.fill(dtype(np.inf))
+                age = np.nan
+                return (age, x)
+            
+            # Get temp of closest particle
+            particle_start_temp = old_temps[neighbor_id == old_ids]
+        
+        # If interpolate turned off, return original profile of np.inf
+        else:
+            x = np.empty(num_nodes, dtype=dtype)
+            x.fill(dtype(np.inf))
+            age = np.nan
+            return (age, x)
+    
+    # Double checking that interpolated particle isn't bugged
+    if profile[0][0] == dtype(np.inf):
+        age = np.nan
+        return (age, profile[0])
+        
+    # passing start and end temperatures to forward model
+    particle_temps = np.array([particle_start_temp[0], particle_end_temp[0]])
+    particle_tsteps = np.array([time_interval, 0])
+
+    age, age_unc, he_tot, pos, v, x = \
+        he.forward_model_he(temps=particle_temps, 
+                            tsteps=particle_tsteps,
+                            system=system,
+                            u=u,
+                            th=th,
+                            radius=radius,
+                            nodes=num_nodes,
+                            initial_x=profile.flatten(),
+                            return_all=True)
+    
+    if calc_age:
+        return (age, x)
+    else:
+        age = np.nan
+        return (age, x)
+    
+
+def run_particle_ft(particle_id, inputs, calc_age, interpolate_vals):  
+    """Calculate FT reduced lengths for a particular ASPECT particle.
+
+    Function to calculate the reduced lengths (unitless) within a hypothetical 
+    grain found in a given particle. This function's primary purpose is to be 
+    run in parallel by run_vtk.
+
+    Parameters
+    ----------
+    particle_id : int
+        ID corresponding to the particle to get the reduced lengths of
+    inputs : tuple
+        k : int
+            Index of the current timestep/mesh being processed.
+        positions : pyvista.core.pyvista_ndarray.pyvista_ndarray
+            x, y, z coordinates of each particle in current mesh
+        tree : scipy.spatial._kdtree.KDTree or None
+            K-d tree containing the positions of particles from the previous
+            timestep. Unused (and typically set to None) if interpolate_vals
+            is False.
+        ids : pyvista.core.pyvista_ndarray.pyvista_ndarray
+            IDs for all particles from the current timestep
+        old_ids : pyvista.core.pyvista_ndarray.pyvista_ndarray
+            IDs for all particles from the previous timestep
+        tree_ids : pyvista.core.pyvista_ndarray.pyvista_ndarray or None
+            IDs for all particles with profiles from the previous timestep. Not
+            used (and typically set to False) if interpolate_vals is True.
+        mesh_temps : pyvista.core.pyvista_ndarray.pyvista_ndarray
+            Temperatures for all particles from the current timestep
+        old_temps : pyvista.core.pyvista_ndarray.pyvista_ndarray
+            Temperatures for all particles from the previous timestep
+        old_annealing_arrays : NumPy ndarray of NumPy arrays of floats
+            r values for all particles from the previous timestep
+        time_interval : float
+            Time elapsed between mesh files (Myr)
+        system : string
+            Isotopic system to model. Not used for FT system (but included as a
+            parameter for symmetry with run_particle_he)
+        r_length : int
+            Length of the r arrays for particles that have them
+        model_inputs : tuple       
+            dpar : float
+                Etch figure length (micrometers).
+            annealing_model : string
+                Annealing model to use. Currently, the only acceptable value is
+                'Ketcham99', which corresponds to the fanning curvilinear model 
+                from Ketcham et al. (1999).
+    calc_age : bool
+        Boolean indicating whether to calculate age of particle. If False,
+        age is returned as np.nan.
+    interpolate_vals : bool
+        Boolean indicating whether to interpolate FT data from nearest neighbor
+        of the particle if the particle itself lacks FT data. If False and the
+        particle is missing FT data, an age of np.nan and a profile filled with 
+        np.inf are returned.
+
+    Returns
+    -------
+    age : float
+        Age of the particle. This equals np.nan if calc_age is False or there
+        is an issue obtaining the age of the particle
+    r : NumPy array of floats
+        Updated reduced lengths (unitless) for a hyppothetical grain located 
+        within this particle.
+
+    """
+    # Use float64 to match nans
+    dtype = np.float64
+    
+    # Unpack inputs
+    (k, positions, tree, ids, old_ids, tree_ids, mesh_temps, old_temps, 
+     old_annealing_arrays, time_interval, system, 
+     r_length, (dpar, annealing_model)) = inputs
+    
+    ft_constants = {'Ketcham99': aft.KETCHAM_99_FC}
+    
+    # Get old profile and temperature for current particle if present
+    r_initial = old_annealing_arrays[particle_id == old_ids]
+    particle_start_temp = old_temps[particle_id == old_ids]
+
+    # Create variable to track if missing old data for particle
+    missing = False
+     
+    # If array is empty, assign np.nan
+    # If r_initial is filled with np.inf (i.e, we have a bugged particle), 
+    # return (NaN, r_initital)
+    if r_initial.size == 0:
+        r_initial = np.empty(r_length, dtype=dtype)
+        r_initial.fill(np.nan) 
+        missing = True
+    elif r_initial[0][0] == dtype(np.inf):
+        age = np.nan
+        return (age, r_initial[0])
+    else:
+        r_initial = r_initial[0]
+    
+    # Get final particle temperature
+    particle_end_temp = mesh_temps[ids == particle_id]
+       
+    # If particle not found, don't attempt to calculate profile or age
+    if particle_end_temp.size == 0:            
+        x = np.empty(r_length, dtype=dtype)
+        x.fill(dtype(np.inf))
+        age = np.nan
+        return (age, x)
+    
+    if missing:
+        
+        # Use annealing from nearest neighbor in previous timestep if needed
+        if interpolate_vals:
+        
+            # Get particle position
+            particle_position = positions[ids == particle_id]
+            
+            # Find closest particle
+            distance, index = tree.query(particle_position)
+            
+            # Get id of closest particle
+            neighbor_id = tree_ids[index]
+            
+            # Get profile of closest particle
+            try:
+                r_initial = old_annealing_arrays[neighbor_id == old_ids][0]
+            except Exception:
+                warnings.warn("Warning: likely multi-dimensional id", 
+                              stacklevel=2)
+                x = np.empty(r_length, dtype=dtype)
+                x.fill(dtype(np.inf))
+                age = np.nan
+                return (age, x)
+
+            # Get temp of closest particle
+            particle_start_temp = old_temps[neighbor_id == old_ids]
+        
+        # If turned off, return np.nan
+        else:
+            x = np.empty(r_length, dtype=dtype)
+            x.fill(dtype(np.inf))
+            age = np.nan
+            return (age, x)
+    
+    # Double checking that interpolated particle isn't bugged
+    if r_initial[0] == dtype(np.inf):
+        age = np.nan
+        return (age, r_initial)
+        
+    # Getting average temperature
+    particle_temp = (particle_start_temp[0] + particle_end_temp[0]) / 2
+    
+    # For basic annealing calculations, absolute time doesn't matter -
+    # we just need to maintain difference between start and end times
+    # (start time > end time because the function measures time in yrs BP)
+    r = aft.calc_annealing(r_initial, particle_temp, start=time_interval, 
+                           end=0, next_nan_index=k - 1, 
+                           constants=ft_constants[annealing_model])
+
+    # Only perform age calculations if necessary
+    if calc_age:
+        r_so_far = aft.dpar_conversion(r_mr=r[~np.isnan(r)], 
+                                       dpar=dpar, 
+                                       constants=ft_constants[annealing_model])
+        tsteps = np.arange(start=k * time_interval, 
+                           stop=-0.5 * time_interval, 
+                           step=-1 * time_interval)
+        age = aft.calc_aft_age(r_so_far, tsteps)
+        return (age, r)
+        
+    else:    
+        age = np.nan
+        return (age, r)
+    
+
+def run_vtk(files, system, time_interval, 
+            u=100, th=100, radius=50, num_nodes=513,
+            dpar=1.75, annealing_model='Ketcham99',
+            file_prefix='meshes_tchron', path='./', 
+            temp_dir='~/dump',
+            batch_size=100, processes=None, interpolate_vals=True, 
+            all_timesteps=True, overwrite=False):
+    """Perform parallel He or FT forward modeling of ASPECT VTK data.
+
+    This code performs forward modeling of the AHe, ZHe, or AFT systems
+    across ASPECT VTK data. Data is output as .vtu folders in a new
+    directory, with data for every timestep given. 
+    
+    Parameters
+    ----------
+    files : list of strings
+        List of paths to vtu files to run forward model on. Files are
+        processed in the order they are given in the list.
+    system : string
+        Isotopic system to model. Current options are:
+            'AHe': Apatite (U-Th) / He
+            'ZHe': Zircon (U-Th) / He
+            'AFT': Apatite Fission Track
+    time_interval : float
+        Interval (Myrs) between times when each mesh was produced
+    u : float, optional
+        U concentration (ppm). Default is 100 ppm. Only used if system is 'AHe'
+        or 'ZHe'.
+    th : float, optional
+        Th concentration (ppm). Default is 100 ppm. Only used if system is 'AHe'
+        or 'ZHe'.
+    num_nodes : int 
+        Number of nodes within the grain (for He) (default: 513). Unused for FT 
+        system
+    radius : float, optional
+        Radius of the grain (micrometers). Default is 50 micrometers. Only used 
+        if system is 'AHe' or 'ZHe'.
+    dpar : float, optional
+        Etch figure length (micrometers). Default is 1.75 micrometers. Only used
+        if system is 'AFT'.
+    annealing_model : string, optional
+        Annealing model to use. Currently, the only acceptable value is
+        'Ketcham99', which corresponds to the fanning curvilinear model from
+        Ketcham et al. (1999). Default is 'Ketcham99'. Only used if system is
+        'AFT'.
+    file_prefix : string
+        Prefix to give output files (default: 'meshes_tchron')
+    path : string
+        Path to output directory (default: './')
+    temp_dir : string
+        Path to temporary output directory
+    batch_size : int or 'auto', optional
+        Number of batches to be dispatched to each worker at a time during 
+        parallel computation (default: 100). If set to 'auto', this value is
+        dynamically adjusted during computations to try to optimize efficiency.
+    processes : int or None, optional
+        Maximum number of processes that can run concurrently. If None, this
+        parameter is internally set to two less than the number of CPUs on the
+        user's system (default: None).
+    interpolate_vals : bool
+        Boolean indicating whether to interpolate particle data from nearest 
+        neighbor if the particle itself lacks He data. If False and the
+        particle is missing data, an age of np.nan is returned for that 
+        particle. (default: True)
+    all_timesteps : bool
+        Boolean indicating whether to calculate ages at each tstep 
+        (default: True)
+    overwrite : bool
+        Boolean indicating whether to overwrite old meshes that already have
+        thermochronometric data for this system for a given timestep. If False, 
+        this function skips timesteps that already have data for this system
+        and uses that data and uses for calculations in subsequent meshes. 
+        (default: False)
+
+    Returns
+    -------
+    This function does not return any values.
+
+    """
+    dtype = np.float32
+    
+    # Setting variables for parallel computation
+    if processes is None:
+        processes = os.cpu_count() - 2
+    
+    pre_dispatch = 2 * processes if batch_size == 'auto' else 2 * batch_size
+    
+    particle_fn = {'AHe': run_particle_he,
+                'ZHe': run_particle_he,
+                'AFT': run_particle_ft}
+    
+    # Setting up directory for temporary memory dumps
+    temp_dir = os.path.expanduser(temp_dir)
+    
+    with suppress(Exception):
+        shutil.rmtree(temp_dir)
+    
+    os.makedirs(temp_dir)
+    
+    # Setting up output directory
+    output_dir = os.path.join(path, file_prefix)
+    os.makedirs(output_dir, exist_ok=True)
+    
+    # Path for dump of cached internal values
+    cache_path = os.path.join(output_dir, 'cache_internal_vals.npy')
+    
+    # internal_len represents the length of the "internal values" array
+    # for the inputted annealing system. For the (U-Th)/He system, this
+    # array is a profile of x values (He concentration times node position)
+    # across all nodes in a grain. For the AFT system, this array contains mean 
+    # reduced lengths of fission tracks formed at each timestep.
+
+    # For AFT system, can use number of files to determine internal_len
+    # (-1 is to account for missing tstep from using averages)
+    # For He systems, can just use the input num_nodes
+    internal_len = len(files) - 1 if system == "AFT" else num_nodes
+    
+    with Parallel(n_jobs=processes,
+                  batch_size=batch_size,
+                  pre_dispatch=pre_dispatch,
+                  temp_folder=temp_dir) as parallel:
+    
+        # Loop through timesteps
+        for k, file in enumerate(files):  
+            
+            # Setting up output file path
+            outfile_name = file_prefix + '_' + str(k).zfill(3) + '.vtu'
+            outfile_path = os.path.join(output_dir, outfile_name)
+            
+            # Check if target mesh already exists
+            if os.path.exists(outfile_path):
+                original_mesh = pv.read(outfile_path)
+
+                # If the mesh only has data from other systems or we're willing
+                # to overwrite old data from the current thermochronologic
+                # system, set that mesh as our input/output mesh (to avoid 
+                # overwriting other system data)
+                if overwrite or system not in original_mesh.point_data:
+                    mesh = original_mesh
+                else:       
+                    # If this mesh exists and has data for the inputted
+                    # thermochronologic system, we now need to see if this is
+                    # the last mesh with data
+                    next_filename = file_prefix + '_' + \
+                        str(k + 1).zfill(3) + '.vtu'
+                    next_filepath = os.path.join(output_dir, next_filename)
+                    
+                    # If this mesh is the last mesh in the directory with
+                    # data for the current system, load values from cache
+                    next_mesh_exists = os.path.exists(next_filepath)
+                    if (not next_mesh_exists) or \
+                        (system not in pv.read(next_filepath).point_data):
+                        ids = original_mesh['id']
+                        positions = original_mesh.points
+                        mesh_temps = original_mesh['T']
+                        new_internal_vals = np.load(cache_path)
+                    
+                    # Since the current mesh is complete, there's nothing left
+                    # to do with it, so we can continue to the next mesh
+                    continue
+            
+            else:
+                # If no output mesh exists for this timestep, use the provided
+                # file as our mesh for this timestep
+                mesh = pv.read(file)
+            
+            # Check if we're in the first timestep
+            if k == 0:
+                num_particles = len(mesh['T'])
+
+                # Set up empty arrays for first timestep
+                new_internal_vals = np.empty((num_particles, internal_len), 
+                                             dtype=dtype)
+                new_internal_vals.fill(np.nan)
+                np.save(cache_path, new_internal_vals)
+
+                # Publish ages at 0
+                ages = np.zeros(num_particles)
+                mesh[system] = ages
+                mesh.save(outfile_path)
+
+            elif k > 0:  
+                # If this is not the first timestep, take the "new" data
+                # from the previous timestep and rename it as the "old" data
+                old_internal_vals = new_internal_vals
+                old_ids = ids
+                old_positions = positions
+                old_temps = mesh_temps
+            
+            # Memory management
+            gc.collect()
+            if k in np.arange(5, len(files), 5):
+                shutil.rmtree(temp_dir)
+                os.makedirs(temp_dir)
+            
+            # Extracting data from mesh
+            mesh_temps = mesh['T']
+            ids = mesh['id']
+            positions = mesh.points
+
+            # Run the forward model if we've seen at least 2 timesteps
+            if k > 0:
+            
+                # Set up KDTree for timestep if doing interpolation
+                if interpolate_vals:
+                    
+                    # Get particle ids of particles with internal_vals
+                    has_vals = ~np.isnan(old_internal_vals).all(axis=1)
+                    tree_ids = old_ids[has_vals]
+                    
+                    # Get positions of other particles
+                    other_positions = old_positions[has_vals]
+
+                    # Note: At k=0, all particles have internal_vals but
+                    #       they're all set to NaN, so what we used above
+                    #       doesn't and work and we need a special case
+                    if k == 1:
+                        tree_ids = old_ids
+                        other_positions = old_positions
+                    
+                    # Set up KDTree to find closest particle
+                    tree = KDTree(other_positions)
+                    
+                else:
+                    tree = None
+                    tree_ids = None
+
+                # Set up inputs for run_particle function
+                if system == 'AFT':
+                    model_inputs = (dpar, annealing_model)
+                else:
+                    model_inputs = (u, th, radius)
+                    
+                inputs = (k, positions, tree, ids, old_ids, tree_ids, 
+                          mesh_temps, old_temps, old_internal_vals,
+                          time_interval, system, internal_len, model_inputs)
+                    
+                # Calculate ages if indicated or if on last timestep
+                calc_age = all_timesteps or k == len(files) - 1
+                
+                prog_bar_txt = "Timestep " + str(k)
+                
+                # Calculate new x profiles/annealed lengths and ages in parallel
+                output = parallel(
+                    delayed(particle_fn[system])
+                    (particle, inputs, calc_age, interpolate_vals)
+                    for particle in tqdm(ids, position=0, desc=prog_bar_txt)
+                    )
+                
+                ages, new_internal_vals = zip(*output)
+            
+                # Convert new_internal_vals to array and save for reload
+                new_internal_vals = np.array(new_internal_vals, dtype=dtype)
+                np.save(cache_path, new_internal_vals)
+            
+                # Assign ages to mesh
+                mesh.point_data[system] = np.array(ages, dtype=dtype)
+            
+                # Save new mesh
+                mesh.save(outfile_path)
+                
+                # Purge the temp folder
+                with suppress(Exception):
+                    shutil.rmtree(temp_dir)
+                os.makedirs(temp_dir)
+    
+    # Delete cached values when all finished
+    os.remove(cache_path)
+    gc.collect()
+
+    return
+    
+
+def run_tt_paths(temp_paths, tsteps, system, 
+                 u=100, th=100, radius=50,
+                 dpar=1.75, annealing_model='Ketcham99',
+                 batch_size=100, processes=None,
+                 **kwargs):
+    """Run forward model of a given isotopic system across multiple t-T paths.
+
+    Parameters
+    ----------
+    temp_paths : list of NumPy arrays of floats
+        List of NumPy arrays of floats containing the temperatures (K) at each
+        timestep in tsteps. Each array corresponds to a different grain
+        to obtain a thermochronometric age for.
+    tsteps : Numpy array of floats
+        Array of times (Ma) in chronological (descending) order. First 
+        time is start of first timestep, last time is end of last timestep. 
+        Each pair of adjacent times composes a timestep. The time at a given
+        index i corresponds to the temperatures at index i of each of the NumPy
+        arrays in temp_paths.
+    system : string
+        Isotopic system to model. Current options are:
+            'AHe': Apatite (U-Th) / He
+            'ZHe': Zircon (U-Th) / He
+            'AFT': Apatite Fission Track
+    u : float, optional
+        U concentration (ppm). Default is 100 ppm. Only used if system is 'AHe'
+        or 'ZHe'.
+    th : float, optional
+        Th concentration (ppm). Default is 100 ppm. Only used if system is 'AHe'
+        or 'ZHe'.
+    radius : float, optional
+        Radius of the grain (micrometers). Default is 50 micrometers. Only used 
+        if system is 'AHe' or 'ZHe'.
+    dpar : float, optional
+        Etch figure length (micrometers). Default is 1.75 micrometers. Only used
+        if system is 'AFT'.
+    annealing_model : string, optional
+        Annealing model to use. Currently, the only acceptable value is
+        'Ketcham99', which corresponds to the fanning curvilinear model from
+        Ketcham et al. (1999). Default is 'Ketcham99'. Only used if system is
+        'AFT'.
+    batch_size : int or 'auto', optional
+        Number of batches to be dispatched to each worker at a time during 
+        parallel computation (default: 100). If set to 'auto', this value is
+        dynamically adjusted during computations to try to optimize efficiency.
+    processes : int or None, optional
+        Maximum number of processes that can run concurrently. If None, this
+        parameter is internally set to two less than the number of CPUs on the
+        user's system (default: None).
+    **kwargs : optional
+        Additional arguments to pass to the forward model function of the
+        corresponding isotopic system
+
+    Returns
+    -------
+    ages : list of floats
+        Thermochronometric ages for the given isotopic system for grains that 
+        experienced each of the provided time series. All (U-Th) / He ages 
+        returned are corrected ages. 
+    
+    """
+    if processes is None:
+        processes = os.cpu_count() - 2
+
+    # Setting how many tasks to initially dispatch to workers
+    pre_dispatch = 2 * processes if batch_size == 'auto' else 2 * batch_size
+
+    model_fn = {'AHe': he.forward_model_he,
+                'ZHe': he.forward_model_he,
+                'AFT': aft.forward_model_aft}
+    ft_constants = {'Ketcham99': aft.KETCHAM_99_FC}
+
+    he_inputs = (tsteps, system, u, th, radius)
+    ft_inputs = (tsteps, dpar, ft_constants[annealing_model])
+
+    model_inputs = {'AHe': he_inputs,
+                    'ZHe': he_inputs,
+                    'AFT': ft_inputs}
+    
+    output = Parallel(n_jobs=processes,
+                  batch_size=batch_size,
+                  pre_dispatch=pre_dispatch)(
+                    delayed(model_fn[system])(path, 
+                                              *model_inputs[system], 
+                                              **kwargs)
+                    for path in tqdm(temp_paths, position=0))
+    
+    return output

--- a/tests/test_parallel_vtk.py
+++ b/tests/test_parallel_vtk.py
@@ -309,7 +309,7 @@ def test_run_vtk_interpolate_no_overwrite():
     # Delete old directories
     prefix = 'meshes_'
     for sys in ['AHe', 'ZHe', 'AFT']:
-        with suppress(Exception):
+        with suppress(FileNotFoundError):
             shutil.rmtree('./' + prefix + sys + '_int')
 
     # Generate dummy VTK files for testing

--- a/tests/test_parallel_vtk.py
+++ b/tests/test_parallel_vtk.py
@@ -1,16 +1,456 @@
 """Tests for parallel_vtk module."""
+import os
+import shutil
+from contextlib import suppress
+
 import numpy as np
+import pytest
 import pyvista as pv
+from scipy.spatial import KDTree
 
-# Generate dummy VTK files for testing
-for x in range(10):
-    # Create very small mesh with 16 points and assign each an id and temp 
-    mesh = pv.ImageData(dimensions=(4, 4, 1)).cast_to_unstructured_grid()
-    mesh['id'] = np.arange(16)
-    # Make temperature the same for all points so it cools over time
-    mesh['T'] = 100 - (x * 10 * np.ones(16))
+from gdtchron import _parallel_vtk, aft, he, run_tt_paths, run_vtk
 
-    mesh.save('file_' + str(x) + '.vtu')
+# Constants for t-T series in run_vtk
+NUM_VTU_FILES = 10  # Must be at least 3
+NUM_PARTICLES = 16
+X_DIM = 4
+Y_DIM = 4
+TIME_INTERVAL = 0.2  # Myr
+MAX_TEMP = 400.
+DELTA_TEMP = 10.
 
-# Define times (Ma) for the 10 files
-times = np.arange(9, -1, 1)
+
+def test_run_particle_he():
+    """Unit tests for basic functionality of run_particle_he."""
+    # Create very initial mesh and assign each an id and temp 
+    prev_mesh = pv.ImageData(dimensions=(X_DIM, 
+                                         Y_DIM, 
+                                         1)).cast_to_unstructured_grid()
+    prev_mesh['id'] = np.arange(NUM_PARTICLES)
+    prev_mesh['T'] = MAX_TEMP * np.ones(NUM_PARTICLES)
+
+    # Create next mesh with (mostly) same ids and temps
+    mesh = pv.ImageData(dimensions=(X_DIM, 
+                                    Y_DIM, 
+                                    1)).cast_to_unstructured_grid()
+    id_array = np.arange(NUM_PARTICLES)
+    id_array[1] = NUM_PARTICLES + 1
+    mesh['id'] = id_array
+
+    temp_array = MAX_TEMP - DELTA_TEMP * np.ones(NUM_PARTICLES)
+    temp_array[1] = MAX_TEMP
+    mesh['T'] = temp_array
+
+    # Create final mesh
+    final_mesh = pv.ImageData(dimensions=(X_DIM, 
+                                          Y_DIM, 
+                                          1)).cast_to_unstructured_grid()
+    final_mesh['id'] = np.arange(NUM_PARTICLES)
+
+    temp_array = MAX_TEMP - 2 * DELTA_TEMP * np.ones(NUM_PARTICLES)
+    temp_array[1] = MAX_TEMP
+    final_mesh['T'] = temp_array
+    
+    # Set variables for inputs for all rounds of run_particle
+    internal_len = 513
+    system = 'AHe'
+    model_inputs = (100, 100, 50)
+
+    # Set variables for inputs for first round of run_particle
+    k = 1
+    positions = mesh.points
+    tree = KDTree(prev_mesh.points)
+    ids = mesh['id']
+    old_ids = prev_mesh['id']
+    tree_ids = old_ids
+    temps = mesh['T']
+    old_temps = prev_mesh['T']
+    old_internal_vals = np.empty((NUM_PARTICLES, internal_len))
+    old_internal_vals.fill(np.nan)
+                    
+    inputs = (k, positions, tree, ids, old_ids, tree_ids, temps, old_temps, 
+              old_internal_vals, TIME_INTERVAL, system, internal_len, 
+              model_inputs)
+
+    for i in range(NUM_PARTICLES):
+        age, r = _parallel_vtk.run_particle_he(particle_id=id_array[i], 
+                                               inputs=inputs, 
+                                               calc_age=True, 
+                                               interpolate_vals=True)
+        old_internal_vals[i] = r
+
+        if i == 1:
+            curr_temps = np.array([MAX_TEMP, MAX_TEMP])
+        else:
+            curr_temps = np.array([MAX_TEMP, MAX_TEMP - DELTA_TEMP])
+        curr_tsteps = np.array([TIME_INTERVAL, 0])
+        assert age == pytest.approx(he.forward_model_he(temps=curr_temps,
+                                                        tsteps=curr_tsteps,
+                                                        system=system,
+                                                        u=100,
+                                                        th=100,
+                                                        radius=50))
+        
+    # Set variables for inputs for second round of run_particle
+    k = 2
+    positions = final_mesh.points
+    tree = KDTree(mesh.points)
+    ids = final_mesh['id']
+    old_ids = mesh['id']
+    tree_ids = old_ids
+    temps = final_mesh['T']
+    old_temps = mesh['T']
+                    
+    inputs = (k, positions, tree, ids, old_ids, tree_ids, temps, old_temps, 
+              old_internal_vals, TIME_INTERVAL, system, internal_len, 
+              model_inputs)
+    
+    for i in range(NUM_PARTICLES):
+        age, r = _parallel_vtk.run_particle_he(particle_id=i, 
+                                               inputs=inputs, 
+                                               calc_age=True, 
+                                               interpolate_vals=True)
+
+        if i == 1:
+            curr_temps = np.array([MAX_TEMP, MAX_TEMP, MAX_TEMP])
+        else:
+            curr_temps = np.array([MAX_TEMP, 
+                                   MAX_TEMP - DELTA_TEMP,
+                                   MAX_TEMP - 2 * DELTA_TEMP])
+        curr_tsteps = np.array([2 * TIME_INTERVAL, TIME_INTERVAL, 0])
+        assert age == pytest.approx(he.forward_model_he(temps=curr_temps,
+                                                        tsteps=curr_tsteps,
+                                                        system=system,
+                                                        u=100,
+                                                        th=100,
+                                                        radius=50))
+
+
+def test_run_particle_ft():
+    """Unit tests for basic functionality of run_particle_ft."""
+    # Create very initial mesh and assign each an id and temp 
+    prev_mesh = pv.ImageData(dimensions=(X_DIM, 
+                                         Y_DIM, 
+                                         1)).cast_to_unstructured_grid()
+    prev_mesh['id'] = np.arange(NUM_PARTICLES)
+    prev_mesh['T'] = MAX_TEMP * np.ones(NUM_PARTICLES)
+
+    # Create next mesh with (mostly) same ids and temps
+    mesh = pv.ImageData(dimensions=(X_DIM, 
+                                    Y_DIM, 
+                                    1)).cast_to_unstructured_grid()
+    id_array = np.arange(NUM_PARTICLES)
+    id_array[1] = NUM_PARTICLES + 1
+    mesh['id'] = id_array
+
+    temp_array = MAX_TEMP - DELTA_TEMP * np.ones(NUM_PARTICLES)
+    temp_array[1] = MAX_TEMP
+    mesh['T'] = temp_array
+
+    # Create final mesh
+    final_mesh = pv.ImageData(dimensions=(X_DIM, 
+                                          Y_DIM, 
+                                          1)).cast_to_unstructured_grid()
+    final_mesh['id'] = np.arange(NUM_PARTICLES)
+
+    temp_array = MAX_TEMP - 2 * DELTA_TEMP * np.ones(NUM_PARTICLES)
+    temp_array[1] = MAX_TEMP
+    final_mesh['T'] = temp_array
+    
+    # Set variables for inputs for all rounds of run_particle
+    internal_len = 2
+    system = 'AFT'
+    model_inputs = (1.75, 'Ketcham99')
+
+    # Set variables for inputs for first round of run_particle
+    k = 1
+    positions = mesh.points
+    tree = KDTree(prev_mesh.points)
+    ids = mesh['id']
+    old_ids = prev_mesh['id']
+    tree_ids = old_ids
+    temps = mesh['T']
+    old_temps = prev_mesh['T']
+    old_internal_vals = np.empty((NUM_PARTICLES, internal_len))
+    old_internal_vals.fill(np.nan)
+                    
+    inputs = (k, positions, tree, ids, old_ids, tree_ids, temps, old_temps, 
+              old_internal_vals, TIME_INTERVAL, system, internal_len, 
+              model_inputs)
+    
+    for i in range(NUM_PARTICLES):
+        age, r = _parallel_vtk.run_particle_ft(particle_id=id_array[i], 
+                                               inputs=inputs, 
+                                               calc_age=True, 
+                                               interpolate_vals=True)
+        old_internal_vals[i] = r
+
+        if i == 1:
+            curr_temps = np.array([MAX_TEMP, MAX_TEMP])
+        else:
+            curr_temps = np.array([MAX_TEMP, MAX_TEMP - DELTA_TEMP])
+        curr_tsteps = np.array([TIME_INTERVAL, 0])
+        assert age == pytest.approx(aft.forward_model_aft(temps=curr_temps,
+                                                          tsteps=curr_tsteps,
+                                                          dpar=1.75))
+        
+    # Set variables for inputs for second round of run_particle
+    k = 2
+    positions = final_mesh.points
+    tree = KDTree(mesh.points)
+    ids = final_mesh['id']
+    old_ids = mesh['id']
+    tree_ids = old_ids
+    temps = final_mesh['T']
+    old_temps = mesh['T']
+                    
+    inputs = (k, positions, tree, ids, old_ids, tree_ids, temps, old_temps, 
+              old_internal_vals, TIME_INTERVAL, system, internal_len, 
+              model_inputs)
+    
+    for i in range(NUM_PARTICLES):
+        age, r = _parallel_vtk.run_particle_ft(particle_id=i, 
+                                               inputs=inputs, 
+                                               calc_age=True, 
+                                               interpolate_vals=True)
+
+        if i == 1:
+            curr_temps = np.array([MAX_TEMP, MAX_TEMP, MAX_TEMP])
+        else:
+            curr_temps = np.array([MAX_TEMP, 
+                                   MAX_TEMP - DELTA_TEMP,
+                                   MAX_TEMP - 2 * DELTA_TEMP])
+        curr_tsteps = np.array([2 * TIME_INTERVAL, TIME_INTERVAL, 0])
+        assert age == pytest.approx(aft.forward_model_aft(temps=curr_temps,
+                                                          tsteps=curr_tsteps,
+                                                          dpar=1.75))
+
+
+def test_run_vtk():
+    """Unit tests for basic functionality of run_vtk."""
+    # Generate dummy VTK files for testing
+    filenames = []
+    for x in range(NUM_VTU_FILES):
+        # Create very small mesh with 16 points and assign each an id and temp 
+        mesh = pv.ImageData(dimensions=(X_DIM, 
+                                        Y_DIM, 
+                                        1)).cast_to_unstructured_grid()
+        mesh['id'] = np.arange(NUM_PARTICLES)
+        # Make temperature the same for all points so it cools over time
+        mesh['T'] = MAX_TEMP - (x * DELTA_TEMP * np.ones(NUM_PARTICLES))
+
+        filename = 'file_' + str(x) + '.vtu'
+        mesh.save(filename)
+        filenames.append(filename)
+
+    # Define times (Ma) and temps (K) for the 10 files
+    times = np.arange(start=TIME_INTERVAL * (NUM_VTU_FILES - 1), 
+                      stop=-0.5 * TIME_INTERVAL, 
+                      step=-TIME_INTERVAL)
+    temps = np.arange(start=MAX_TEMP, 
+                      stop=MAX_TEMP - (NUM_VTU_FILES - 0.5) * DELTA_TEMP, 
+                      step=-DELTA_TEMP)
+    
+    # Test using the same mesh for data from multiple systems
+    run_vtk(files=filenames,
+            system='AHe',
+            time_interval=TIME_INTERVAL,
+            file_prefix='meshes_tchron',
+            overwrite=True)
+    
+    run_vtk(files=filenames,
+            system='ZHe',
+            time_interval=TIME_INTERVAL,
+            file_prefix='meshes_tchron',
+            overwrite=True)
+
+    run_vtk(files=filenames,
+            system='AFT',
+            time_interval=TIME_INTERVAL,
+            file_prefix='meshes_tchron',
+            overwrite=True)
+    
+    # Make sure calling run_vtk again doesn't overwrite AFT/ZHe data
+    run_vtk(files=filenames,
+            system='AHe',
+            time_interval=TIME_INTERVAL,
+            file_prefix='meshes_tchron',
+            overwrite=True)
+    
+    for i in range(NUM_VTU_FILES):
+        prefix = 'meshes_tchron'
+        suffix = '_' + str(i).zfill(3) + '.vtu'
+        mesh = pv.read(os.path.join('./' + prefix, prefix + suffix))
+
+        # Test all systems
+        for sys in ['AHe', 'ZHe', 'AFT']:
+            if i == 0:
+                assert np.array(mesh[sys]) == \
+                    pytest.approx(np.ones(NUM_PARTICLES) * 0.)
+            else:
+                if sys[1:] == 'He':
+                    expected_age = he.forward_model_he(temps=temps[:i + 1],
+                                                tsteps=times[:i + 1],
+                                                system=sys,
+                                                u=100,
+                                                th=100,
+                                                radius=50)
+                else:
+                    expected_age = aft.forward_model_aft(temps=temps[:i + 1],
+                                                         tsteps=times[:i + 1],
+                                                         dpar=1.75)
+                assert np.array(mesh[sys]) == \
+                    pytest.approx(np.ones(NUM_PARTICLES) * expected_age, 
+                                  rel=1e-3)
+                
+
+def test_run_vtk_interpolate_no_overwrite():
+    """Unit tests for interpolation and not using overwriting with run_vtk."""
+    # Delete old directories
+    prefix = 'meshes_'
+    for sys in ['AHe', 'ZHe', 'AFT']:
+        with suppress(Exception):
+            shutil.rmtree('./' + prefix + sys + '_int')
+
+    # Generate dummy VTK files for testing
+    filenames = []
+    for x in range(NUM_VTU_FILES):
+        # Create very small mesh with 16 points and assign each an id and temp 
+        mesh = pv.ImageData(dimensions=(4, 4, 1)).cast_to_unstructured_grid()
+        if x == 3:
+            mesh['id'] = np.arange(NUM_PARTICLES)
+        else:
+            mesh['id'] = np.arange(NUM_PARTICLES, NUM_PARTICLES * 2)
+        # Make temperature the same for all but one point
+        mesh['T'] = np.append(MAX_TEMP - (x * DELTA_TEMP * np.ones(15)), 
+                              MAX_TEMP)
+
+        filename = 'file_interp_' + str(x) + '.vtu'
+        mesh.save(filename)
+        filenames.append(filename)
+
+    # Define times (Ma) and temps (K) for the 10 files
+    times = np.arange(start=TIME_INTERVAL * (NUM_VTU_FILES - 1), 
+                      stop=-0.5 * TIME_INTERVAL, 
+                      step=-TIME_INTERVAL)
+    temps = np.arange(start=MAX_TEMP, 
+                      stop=MAX_TEMP - (NUM_VTU_FILES - 0.5) * DELTA_TEMP, 
+                      step=-DELTA_TEMP)
+    
+    # Temps for the last particle
+    last_temps = np.ones(NUM_VTU_FILES) * MAX_TEMP
+    
+    # Test interpolation (with overwriting)
+    run_vtk(files=filenames,
+            system='AHe',
+            time_interval=TIME_INTERVAL,
+            file_prefix='meshes_AHe_int',
+            overwrite=True)
+
+    # Intentionally crash the ZHe test midway thru
+    with pytest.raises(TypeError):
+        run_vtk(files=filenames[:-1] + [0],
+                system='ZHe',
+                time_interval=TIME_INTERVAL,
+                file_prefix='meshes_ZHe_int',
+                overwrite=True)
+
+    # Test resuming the ZHe code from where the test was interrupted
+    run_vtk(files=filenames,
+            system='ZHe',
+            time_interval=TIME_INTERVAL,
+            file_prefix='meshes_ZHe_int',
+            overwrite=False)
+
+    # Intentionally crash the AFT test midway thru
+    with pytest.raises(TypeError):
+        run_vtk(files=filenames[:-1] + [0],
+                system='AFT',
+                time_interval=TIME_INTERVAL,
+                file_prefix='meshes_AFT_int',
+                overwrite=True)
+
+    # Test resuming the AFT code from where the test was interrupted
+    run_vtk(files=filenames,
+            system='AFT',
+            time_interval=TIME_INTERVAL,
+            file_prefix='meshes_AFT_int',
+            overwrite=False)
+    
+    for i in range(NUM_VTU_FILES):
+        suffix = '_int_' + str(i).zfill(3) + '.vtu'
+
+        # Test all systems
+        for sys in ['AHe', 'ZHe', 'AFT']:
+            mesh = pv.read(os.path.join('./' + prefix + sys + '_int', 
+                                        prefix + sys + suffix))
+            if i == 0:
+                assert np.array(mesh[sys]) == \
+                    pytest.approx(np.ones(NUM_PARTICLES) * 0.)
+            else:
+                if sys[1:] == 'He':
+                    expected_age = he.forward_model_he(temps=temps[:i + 1],
+                                                       tsteps=times[:i + 1],
+                                                       system=sys,
+                                                       u=100,
+                                                       th=100,
+                                                       radius=50)
+                    last_age = he.forward_model_he(temps=last_temps[:i + 1],
+                                                   tsteps=times[:i + 1],
+                                                   system=sys,
+                                                   u=100,
+                                                   th=100,
+                                                   radius=50)
+                else:
+                    expected_age = aft.forward_model_aft(temps=temps[:i + 1],
+                                                         tsteps=times[:i + 1],
+                                                         dpar=1.75)
+                    last_age = aft.forward_model_aft(temps=last_temps[:i + 1],
+                                                     tsteps=times[:i + 1],
+                                                     dpar=1.75)
+                assert np.array(mesh[sys])[:-1] == \
+                    pytest.approx(np.ones(NUM_PARTICLES - 1) * expected_age, 
+                                  rel=1e-3)
+                assert np.array(mesh[sys][-1]) == pytest.approx(last_age, 
+                                                                rel=5e-2)
+
+
+def test_run_tt_paths():
+    """Unit tests for run_tt_paths."""
+    # Test (U-Th) / He system
+    he_times = np.arange(60, -0.001, -0.1)
+    
+    # Constants for test 1
+    early_temps_1 = np.linspace(120, 20, 101)
+    late_temps_1 = np.linspace(20, 20, 500)
+    temps_1 = np.append(early_temps_1, late_temps_1) + 273
+
+    # Constants for test 2
+    temps_2 = np.linspace(120, 20, 601) + 273
+
+    # Constants for test 3
+    early_temps_3 = np.linspace(120, 65, 576) + 273
+    late_temps_3 = np.linspace(65, 20, 26) + 273
+    temps_3 = np.append(early_temps_3, late_temps_3[1:])
+
+    temp_paths = [temps_1, temps_2, temps_3]
+
+    ages = run_tt_paths(temp_paths=temp_paths, 
+                        tsteps=he_times, 
+                        system='AHe',
+                        radius=100,
+                        processes=3)
+
+    assert ages[0] == pytest.approx(54.4, rel=5e-3)
+    assert ages[1] == pytest.approx(26.3, rel=5e-2)
+    assert ages[2] == pytest.approx(6.83, rel=1e-1)
+    assert len(ages) == 3
+
+    # Test AFT system (and a singleton list of temps)
+    temps = np.linspace(190.1, 20, 500, endpoint=True)
+    temps += 273.15
+    ft_times = np.linspace(93, 0, 500, endpoint=True)
+
+    age_list = run_tt_paths(temp_paths=[temps], tsteps=ft_times, system='AFT')
+    assert age_list[0] == pytest.approx(39.8, rel=5e-3)
+    assert len(age_list) == 1


### PR DESCRIPTION
This PR contains the latest version of the code for `_parallel_vtk.py` with condensed commits and clearer inline comments and variable names. 

The most substantial change left would be consolidating `run_particle_he` and `run_particle_ft` into one function and just putting some conditionals in the function in places where the code differs depending on the system being used. The main benefit to this would be that changes made to code  that is currently shared between functions would only need to be changed in one place instead of two. However, the combined function would be longer and would have to use more vague variable names like `run_vtk` does (e.g, we'd have to use "internal_vals" instead of "r" or "x", which could be more confusing). I don't **think** making this change would be too time-consuming to implement, since most of the code is the same to begin with, but I didn't want to make the change without discussing it first.