### PR TITLE
Update version after first release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dyvasey/gdtchron/HEAD)
 [![Online Documentation](https://readthedocs.org/projects/gdtchron/badge/?version=latest)](https://gdtchron.readthedocs.io/en/latest/)
+[![PyPI - Version](https://img.shields.io/pypi/v/gdtchron)](https://pypi.org/project/gdtchron/)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/gdtchron/badges/version.svg)](https://anaconda.org/conda-forge/gdtchron)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15864962.svg)](https://doi.org/10.5281/zenodo.15864962)
+
 
 ## About
 GDTchron is a Python package for using the outputs of geodynamic models to predict thermochronometric ages.
@@ -14,6 +18,7 @@ Current authors:
 * Dylan Vasey
 * Peter Scully
 * John Naliboff
+* Sascha Brune
 
 Source code: https://github.com/dyvasey/gdtchron
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,9 +7,9 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'GDTchron'
-copyright = '2025, Dylan Vasey, Peter Scully, John Naliboff'
-author = 'Dylan Vasey, Peter Scully, John Naliboff'
-release = '0.1.0'
+copyright = '2025, Dylan Vasey, Peter Scully, John Naliboff, Sascha Brune'
+author = 'Dylan Vasey, Peter Scully, John Naliboff, Sascha Brune'
+release = '0.1.1.dev0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [tool.poetry]
 name = "gdtchron"
-version = "0.1.0"
+version = "0.1.1.dev0"
 description = "Thermochronology for geodynamic models"
 authors = [
   "Dylan Vasey <dylan.vasey@tufts.edu>", "Peter Scully <peter.scully@tufts.edu>",
-  "John Naliboff <john.naliboff@nmt.edu>"
+  "John Naliboff <john.naliboff@nmt.edu>", "Sascha Brune <brune@gfz.de>"
 ]
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
This bumps the version to 0.1.1.dev0 after the initial release and adds PyPI, conda-forge, and Zenodo badges to the README.