### PR TITLE
Update libgl1 dependency for Binder

### DIFF
--- a/.binder/apt.txt
+++ b/.binder/apt.txt
@@ -1,4 +1,4 @@
 # This file identifies apt packages needed for Binder to use Pyvista 
 # in headless mode.
-libgl1-mesa-glx
+libgl1
 xvfb

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Online Documentation](https://readthedocs.org/projects/gdtchron/badge/?version=latest)](https://gdtchron.readthedocs.io/en/latest/)
 [![PyPI - Version](https://img.shields.io/pypi/v/gdtchron)](https://pypi.org/project/gdtchron/)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/gdtchron/badges/version.svg)](https://anaconda.org/conda-forge/gdtchron)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15864962.svg)](https://doi.org/10.5281/zenodo.15864962)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15864961.svg)](https://doi.org/10.5281/zenodo.15864961)
 
 
 ## About


### PR DESCRIPTION
This is a PR just to update dependencies for Binder due to a package name change for the latest version of Ubuntu.